### PR TITLE
Set border-collapse to separate to fix overlap

### DIFF
--- a/dist/github-calendar.css
+++ b/dist/github-calendar.css
@@ -28,6 +28,7 @@
 
 table.ContributionCalendar-grid {
     margin-bottom: 0pt;
+    border-collapse: separate;
 }
 
 table.ContributionCalendar-grid td {


### PR DESCRIPTION
Added 'border-collapse: separate;' to the ContributionCalendar-grid table to adjust table border rendering.
Fixes #181 

<img width="2354" height="336" alt="image" src="https://github.com/user-attachments/assets/02791777-1fea-40a8-a621-c82cc97fb379" />

<img width="2280" height="344" alt="image" src="https://github.com/user-attachments/assets/a82c9993-56b0-4d8a-af26-7d7141afcee9" />
